### PR TITLE
localStorage keeps votes for inital count but rolls over after refresh

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -66,6 +66,7 @@ function voteMade(event){
   for (i = 0; i < images.length; i++){
     if (winnerName == images[i].fileName){
       images[i].y += 1;
+      localStorage.setItem(images[i].label, images[i].y);
     };
   };
   if (totalClicks == 15){


### PR DESCRIPTION
localStorage holds image votes counts beyond a refresh but overwrites instead of adding total votes after the refresh 